### PR TITLE
Fix fabric deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ build
 fabricbeat/_meta/dashboards.yml
 fabricbeat
 !fabricbeat/
+agent/fabricbeat/fields.yml
 
 # Dumper application
 dumper

--- a/agent/fabricbeat/Makefile
+++ b/agent/fabricbeat/Makefile
@@ -41,11 +41,20 @@ git-add:
 
 .PHONY: clean
 go-get:
+	go get -v github.com/hyperledger/fabric/core/ledger
+	go get -v github.com/hyperledger/fabric/common/util
+	go get -v github.com/hyperledger/fabric/protoutil
+	# these packages are included twice
+	# also present in github.com/golang.org/x/net/trace
+	rm -rf ../../../hyperledger/fabric/vendor/golang.org/x/net/trace
+	# also present outside vendor, need to delete vendored package to avoid type def collision
+	rm -rf ../../../hyperledger/fabric/vendor/github.com/hyperledger/fabric-protos-go
+	rm -rf ../../../hyperledger/fabric/vendor/github.com/golang/protobuf
 	go get github.com/go-kit/kit/sd
 	cd ../../../go-kit/kit/; git checkout tags/v0.8.0 -b v0.8.0
 	go get github.com/cloudflare/cfssl/csr
 	cd ../../../cloudflare/cfssl; git checkout tags/1.3.3 -b 1.3.3
-	go get
+	go get -v
 	# this package is include twice. also present in github.com/golang.org/x/net/trace
 	rm -rf ../../../hyperledger/fabric/vendor/golang.org/x/net/trace
 go-branch-del:


### PR DESCRIPTION
- `github.com/hyperledger/fabric/protos` has been removed, so changed it to `github.com/hyperledger/fabric-protos-go` in each import statement
- `github.com/hyperledger/fabric/protos/common.BlockHeader.Hash()` function has been removed from `github.com/hyperledger/fabric-protos-go` (to allow configurable hashing algorithms), we have to calculate the hash. We do it the way it was implemented until now: `util.ComputeSHA256(h.Bytes())`
- But `github.com/hyperledger/fabric-protos-go/common.BlockHeader.Bytes()` is also missing, so we have to implement the Byte() function the way it was until now...

All new implementations are based on [this link](https://gowalker.org/github.com/hyperledger/fabric/protos/common#BlockHeader).

Signed-off-by: Balazs Prehoda <prehoda.balazs@gmail.com>