### PR TITLE
Containerization and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ build
 .DS_Store
 
 fabricbeat/_meta/dashboards.yml
-fabricbeat
+agent/fabricbeat/fabricbeat
 !fabricbeat/
 agent/fabricbeat/fields.yml
 

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ build
 fabricbeat/_meta/dashboards.yml
 fabricbeat
 !fabricbeat/
+agent/fabricbeat/fields.yml
 
 # Dumper application
 dumper

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.12.7
+
+# Python 2.7
+RUN apt update && apt-get install python -y
+RUN apt install virtualenv -y
+
+# Pre-built executable
+COPY ./agent/fabricbeat/prebuilt/Ubuntu-bionic-18.04 $GOPATH/src/github.com/blockchain-analyzer/agent/fabricbeat
+
+WORKDIR $GOPATH/src/github.com/blockchain-analyzer/agent/fabricbeat
+
+ENTRYPOINT chown root fabricbeat.yml && ./fabricbeat -e -d "*"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM golang:1.12.7
+FROM golang:1.13.0
 
-# Python 2.7
-RUN apt update && apt-get install python -y
-RUN apt install virtualenv -y
-
-# Pre-built executable
-COPY ./agent/fabricbeat/prebuilt/Ubuntu-bionic-18.04 $GOPATH/src/github.com/blockchain-analyzer/agent/fabricbeat
+COPY ./.git $GOPATH/src/github.com/blockchain-analyzer/.git
+COPY ./agent $GOPATH/src/github.com/blockchain-analyzer/agent
 
 WORKDIR $GOPATH/src/github.com/blockchain-analyzer/agent/fabricbeat
 
-ENTRYPOINT chown root fabricbeat.yml && ./fabricbeat -e -d "*"
+RUN rm go.mod go.sum
+
+RUN apt-get update && apt-get install make -y
+RUN make go-get
+RUN apt-get update && apt-get install virtualenv -y
+RUN make update
+RUN make
+
+ENTRYPOINT chown root fabricbeat.yml && chmod 644 fabricbeat.yml && ./fabricbeat -e -d "*"
 

--- a/agent/agentmodules/fabricutils/fabricutils.go
+++ b/agent/agentmodules/fabricutils/fabricutils.go
@@ -1,20 +1,17 @@
 package fabricutils
 
 import (
-	"encoding/asn1"
 	"encoding/hex"
 	"encoding/pem"
 	"strings"
-	"fmt"
-	"math"
 
 	"github.com/blockchain-analyzer/agent/agentmodules/fabricsetup"
 
 	"github.com/gogo/protobuf/proto"
 
-	"github.com/hyperledger/fabric/protoutil"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/msp"
+	"github.com/hyperledger/fabric/protoutil"
 )
 
 // Generates block hash from previous hash, data hash and block number.

--- a/agent/agentmodules/fabricutils/fabricutils.go
+++ b/agent/agentmodules/fabricutils/fabricutils.go
@@ -1,53 +1,29 @@
 package fabricutils
 
 import (
-	"encoding/asn1"
 	"encoding/hex"
 	"encoding/pem"
 	"strings"
-	"fmt"
-	"math"
 
 	"github.com/blockchain-analyzer/agent/agentmodules/fabricsetup"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/hyperledger/fabric/common/util"
+
+	"github.com/hyperledger/fabric/protoutil"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/msp"
 )
 
-type asn1Header struct {
-	Number       int64
-	PreviousHash []byte
-	DataHash     []byte
-}
 
 // Generates block hash from previous hash, data hash and block number.
 func GenerateBlockHash(previousHash, dataHash []byte, blockNumber uint64) string {
 
-	h := common.BlockHeader{
+	h := &common.BlockHeader{
 		Number:       blockNumber,
 		PreviousHash: previousHash,
 		DataHash:     dataHash}
 
-	asn1Header := asn1Header{
-		PreviousHash: h.PreviousHash,
-		DataHash:     h.DataHash,
-	}
-	if h.Number > uint64(math.MaxInt64) {
-		panic(fmt.Errorf("Golang does not currently support encoding uint64 to asn1"))
-	} else {
-		asn1Header.Number = int64(h.Number)
-	}
-	asn1Bytes, err := asn1.Marshal(asn1Header)
-	if err != nil {
-		// Errors should only arise for types which cannot be encoded, since the
-		// BlockHeader type is known a-priori to contain only encodable types, an
-		// error here is fatal and should not be propogated
-		panic(err)
-	}
-
-	return hex.EncodeToString(util.ComputeSHA256(asn1Bytes))
+	return hex.EncodeToString(protoutil.BlockHeaderHash(h))
 }
 
 // Decodes the type of the transaction into string

--- a/agent/fabricbeat/Makefile
+++ b/agent/fabricbeat/Makefile
@@ -41,11 +41,20 @@ git-add:
 
 .PHONY: clean
 go-get:
+	go get -v github.com/hyperledger/fabric/core/ledger
+	go get -v github.com/hyperledger/fabric/common/util
+	go get -v github.com/hyperledger/fabric/protoutil
+	# these packages are included twice
+	# also present in github.com/golang.org/x/net/trace
+	rm -rf ../../../hyperledger/fabric/vendor/golang.org/x/net/trace
+	# also present outside vendor, need to delete vendored package to avoid type def collision
+	rm -rf ../../../hyperledger/fabric/vendor/github.com/hyperledger/fabric-protos-go
+	rm -rf ../../../hyperledger/fabric/vendor/github.com/golang/protobuf
 	go get github.com/go-kit/kit/sd
 	cd ../../../go-kit/kit/; git checkout tags/v0.8.0 -b v0.8.0
 	go get github.com/cloudflare/cfssl/csr
 	cd ../../../cloudflare/cfssl; git checkout tags/1.3.3 -b 1.3.3
-	go get
+	go get -v
 	# this package is include twice. also present in github.com/golang.org/x/net/trace
 	rm -rf ../../../hyperledger/fabric/vendor/golang.org/x/net/trace
 go-branch-del:

--- a/agent/fabricbeat/go.mod
+++ b/agent/fabricbeat/go.mod
@@ -18,13 +18,13 @@ exclude github.com/Sirupsen/logrus v1.1.1
 
 exclude github.com/Sirupsen/logrus v1.1.0
 
-go 1.12
+go 1.13
 
 require (
 	github.com/Shopify/sarama v1.23.1 // indirect
 	github.com/Sirupsen/logrus v1.0.6 // indirect
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 // indirect
-	github.com/cloudflare/cfssl 1.3.3 // indirect
+	github.com/cloudflare/cfssl v1.3.3 // indirect
 	github.com/docker/docker v1.13.1 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect

--- a/docker-agent/Makefile
+++ b/docker-agent/Makefile
@@ -1,0 +1,33 @@
+
+#set +x
+
+HLNETWORK?=el-network
+ORG_NUMBER?=1
+NETWORK?=basic
+PEER_NUMBER?=0
+
+WHICHOS := $(shell uname)
+
+start:
+	make generate
+	docker-compose up -d
+	
+destroy:
+	docker-compose down
+	rm -rf *-e
+	rm -rf ./docker-compose*.yaml ./connection-profile*.yaml
+
+generate:
+	cp templates/docker-compose-TEMPLATE.yaml docker-compose.yaml
+	sed -i -e "s/CONFIG_ORG_NUM/${ORG_NUMBER}/g" docker-compose.yaml
+	sed -i -e "s/CONFIG_NETWORK_NAME/${NETWORK}/g" docker-compose.yaml
+	sed -i -e "s/CONFIG_PEER_NUM/${PEER_NUMBER}/g" docker-compose.yaml
+	for NUMBER in 1 2 3 4 ; \
+	do \
+		cp templates/network/${NETWORK}/connection-profile-TEMPLATE.yaml connection-profile-$${NUMBER}.yaml; \
+		sed -i -e  "s/HLNETWORK/${HLNETWORK}/g" connection-profile-$${NUMBER}.yaml; \
+		sed -i -e  "s/ORG/Org$${NUMBER}/g" connection-profile-$${NUMBER}.yaml; \
+	done
+ifeq ($(WHICHOS),Darwin)
+	rm *-e
+endif

--- a/docker-agent/fabricbeat.yml
+++ b/docker-agent/fabricbeat.yml
@@ -1,0 +1,180 @@
+################### Fabricbeat Configuration #########################
+
+
+############################# Fabricbeat ######################################
+
+fabricbeat:
+  # Defines how often an event is sent to the output
+  period: 1s
+  # Defines which organization the connected peer is part of
+  organization: org${ORG_NUMBER}
+  # Defines the peer which fabricbeat should query
+  peer: peer${PEER_NUMBER}.org${ORG_NUMBER}.el-network.com
+  # Defines the location of the connection profile of the Fabric network
+  connectionProfile: ${GOPATH}/src/github.com/blockchain-analyzer/network/${NETWORK}/connection-profile-${ORG_NUMBER}.yaml
+  # Path to the admin certfile and keyfile
+  adminCertPath: "${GOPATH}/src/github.com/blockchain-analyzer/network/${NETWORK}/crypto-config/peerOrganizations/org${ORG_NUMBER}.el-network.com/users/Admin@org${ORG_NUMBER}.el-network.com/msp/signcerts/Admin@org${ORG_NUMBER}.el-network.com-cert.pem"
+  adminKeyPath: "${GOPATH}/src/github.com/blockchain-analyzer/network/${NETWORK}/crypto-config/peerOrganizations/org${ORG_NUMBER}.el-network.com/users/Admin@org${ORG_NUMBER}.el-network.com/msp/keystore/adminKey${ORG_NUMBER}"
+  # URL of Elasticsearch
+  elasticURL: "http://localhost:9200"
+  # URL of Kibana
+  kibanaURL: "http://localhost:5601"
+  # Indices are created from a template (see output.elasticsearch.index). The following settings are to replace the index_name in the template.
+  # Name of index to which the agent should send the block data
+  blockIndexName: block
+  # Name of index to which the agent should send the transaction data
+  transactionIndexName: transaction
+  # Name of index to which the agent should send the key data
+  keyIndexName: key
+  # Folder which should contain the generated dashboards. Note: this directory is going to be erased.
+  dashboardDirectory: ${GOPATH}/src/github.com/blockchain-analyzer/dashboards/7/dashboard
+  # Folder which contains the templates for Kibana objects (index patterns, dashboards, etc.)
+  templateDirectory: ${GOPATH}/src/github.com/blockchain-analyzer/agent/kibana_templates
+
+  chaincodes:
+    # This is the name of the key that links transactions together (e.g. previous_key, link_key, etc.).
+    - linkingkey: previousKey
+      name: dummycc
+      values: [hash]
+    - name: fabcar
+      linkingkey:
+      values: ["make", "model", "colour", "owner"]
+
+#-------------------------- Elasticsearch output ------------------------------
+setup.ilm.enabled: false
+
+output.elasticsearch.index: fabricbeat-%{[agent.version]}-%{[index_name]}-org${ORG_NUMBER}
+output.elasticsearch.hosts: ["localhost:9200"]
+
+setup.template.name: fabricbeat-%{[agent.version]}
+setup.template.pattern: fabricbeat-%{[agent.version]}*
+
+setup.dashboards.directory: ${GOPATH}/src/github.com/blockchain-analyzer/dashboards
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+
+#============================== Dashboards =====================================
+# These settings control loading the sample dashboards to the Kibana index. Loading
+# the dashboards is disabled by default and can be enabled either by setting the
+# options here or by using the `setup` command.
+#setup.dashboards.enabled: false
+
+# The URL from where to download the dashboards archive. By default this URL
+# has a value which is computed based on the Beat name and version. For released
+# versions, this URL points to the dashboard archive on the artifacts.elastic.co
+# website.
+#setup.dashboards.url:
+
+#============================== Kibana =====================================
+
+# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
+# This requires a Kibana endpoint configuration.
+setup.kibana:
+
+  # Kibana Host
+  # Scheme and port can be left out and will be set to the default (http and 5601)
+  # In case you specify and additional path, the scheme is required: http://localhost:5601/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
+  #host: "localhost:5601"
+
+  # Kibana Space ID
+  # ID of the Kibana Space into which the dashboards should be loaded. By default,
+  # the Default Space will be used.
+  #space.id:
+
+#============================= Elastic Cloud ==================================
+
+# These settings simplify using fabricbeat with the Elastic Cloud (https://cloud.elastic.co/).
+
+# The cloud.id setting overwrites the `output.elasticsearch.hosts` and
+# `setup.kibana.host` options.
+# You can find the `cloud.id` in the Elastic Cloud web UI.
+#cloud.id:
+
+# The cloud.auth setting overwrites the `output.elasticsearch.username` and
+# `output.elasticsearch.password` settings. The format is `<user>:<pass>`.
+#cloud.auth:
+
+#================================ Outputs =====================================
+
+# Configure what output to use when sending the data collected by the beat.
+
+#-------------------------- Elasticsearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["localhost:9200"]
+
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "elastic"
+  #password: "changeme"
+
+#----------------------------- Logstash output --------------------------------
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
+
+  # Optional SSL. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+#================================ Processors =====================================
+
+# Configure processors to enhance or manipulate events generated by the beat.
+
+processors:
+  - add_host_metadata: ~
+  - add_cloud_metadata: ~
+
+#================================ Logging =====================================
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: debug
+
+# At debug level, you can selectively enable logging only for some components.
+# To enable all selectors use ["*"]. Examples of other selectors are "beat",
+# "publish", "service".
+#logging.selectors: ["*"]
+
+#============================== Xpack Monitoring ===============================
+# fabricbeat can export internal metrics to a central Elasticsearch monitoring
+# cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
+# reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# Elasticsearch output are accepted here as well.
+# Note that the settings should point to your Elasticsearch *monitoring* cluster.
+# Any setting that is not set is automatically inherited from the Elasticsearch
+# output configuration, so if you have the Elasticsearch output configured such
+# that it is pointing to your Elasticsearch monitoring cluster, you can simply
+# uncomment the following line.
+#monitoring.elasticsearch:
+
+#================================= Migration ==================================
+
+# This allows to enable 6.7 migration aliases
+#migration.6_to_7.enabled: true

--- a/docker-agent/templates/docker-compose-TEMPLATE.yaml
+++ b/docker-agent/templates/docker-compose-TEMPLATE.yaml
@@ -1,0 +1,27 @@
+version: "3"
+
+services:
+
+  fabricbeat:
+    image: balazsprehoda/fabricbeat:v3-alpha
+    # To make resolution of peer container addresses simple (demo purposes!)
+    # In production, you probably want to deploy fabricbeat to the same network
+    # as the Hyperledger Fabric containers.
+    network_mode: host
+    environment:
+      - ORG_NUMBER=CONFIG_ORG_NUM
+      - PEER_NUMBER=CONFIG_PEER_NUM
+      - NETWORK=CONFIG_NETWORK_NAME
+    volumes:
+      # Fabricbeat configuration file
+      - ./fabricbeat.yml:/go/src/github.com/blockchain-analyzer/agent/fabricbeat/fabricbeat.yml
+      # Connection profile ("connectionProfile" in configuration file)
+      - ./connection-profile-CONFIG_ORG_NUM.yaml:/go/src/github.com/blockchain-analyzer/network/CONFIG_NETWORK_NAME/connection-profile-CONFIG_ORG_NUM.yaml
+      # Crypto-config
+      - ../network/CONFIG_NETWORK_NAME/crypto-config:/go/src/github.com/blockchain-analyzer/network/basic/crypto-config
+      # Kibana dashboard directory ("dashboardDirectory" in configuration file)
+      - ../dashboards/7/dashboard:/go/src/github.com/blockchain-analyzer/dashboards/7/dashboard
+      # Kibana template directory ("templateDirectory" in configuration file)
+      - ../agent/kibana_templates:/go/src/github.com/blockchain-analyzer/agent/kibana_templates
+      # Note that if you change "dashboardDirectory", you have to change setup.dashboards.directory accordingly!
+

--- a/docker-agent/templates/network/basic/connection-profile-TEMPLATE.yaml
+++ b/docker-agent/templates/network/basic/connection-profile-TEMPLATE.yaml
@@ -1,0 +1,243 @@
+name: elastic-network
+version: 1.0.0
+license: Apache-2.0
+client:
+  tlsEnable: true
+  adminUser: admin
+  adminPassword: adminpw
+  enableAuthentication: false
+  organization: ORG
+  connection:
+   timeout:
+     peer:
+       endorser: '3000'
+     orderer: '3000'
+  cryptoconfig:
+    path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config"
+
+BCCSP:
+    security:
+     enabled: true
+     default:
+      provider: "SW"
+     hashAlgorithm: "SHA2"
+     softVerify: true
+     level: 256
+
+channels:
+  mychannel:
+    peers:
+      peer0.org1.HLNETWORK.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+      peer0.org2.HLNETWORK.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+      peer0.org3.HLNETWORK.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+      peer0.org4.HLNETWORK.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+    orderers:
+    - orderer.HLNETWORK.com
+    connection:
+      timeout:
+        peer:
+          endorser: '6000'
+          eventHub: '6000'
+          eventReg: '6000'
+        orderer: '6000'
+
+organizations:
+  org1:
+    mspid: Org1MSP
+    fullpath: true
+    peers:
+    - peer0.org1.HLNETWORK.com
+    certificateAuthorities:
+    - ca.org1.HLNETWORK.com
+    cryptopath: peerOrganizations/org1.HLNETWORK.com/msp
+    adminPrivateKey:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org1.HLNETWORK.com/users/Admin@org1.HLNETWORK.com/msp/keystore/adminKey1"
+    signedCert:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org1.HLNETWORK.com/users/Admin@org1.HLNETWORK.com/msp/signcerts/Admin@org1.HLNETWORK.com-cert.pem"
+  org2:
+    mspid: Org2MSP
+    fullpath: true
+    peers:
+    - peer0.org2.HLNETWORK.com
+    certificateAuthorities:
+    - ca.org2.HLNETWORK.com
+    cryptopath: peerOrganizations/org2.HLNETWORK.com/msp
+    adminPrivateKey:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org2.HLNETWORK.com/users/Admin@org2.HLNETWORK.com/msp/keystore/adminKey2"
+    signedCert:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org2.HLNETWORK.com/users/Admin@org2.HLNETWORK.com/msp/signcerts/Admin@org2.HLNETWORK.com-cert.pem"
+  org3:
+    mspid: Org3MSP
+    fullpath: true
+    peers:
+    - peer0.org3.HLNETWORK.com
+    certificateAuthorities:
+    - ca.org3.HLNETWORK.com
+    cryptopath: peerOrganizations/org3.HLNETWORK.com/msp
+    adminPrivateKey:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org3.HLNETWORK.com/users/Admin@org3.HLNETWORK.com/msp/keystore/adminKey3"
+    signedCert:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org3.HLNETWORK.com/users/Admin@org3.HLNETWORK.com/msp/signcerts/Admin@org3.HLNETWORK.com-cert.pem"
+  org4:
+    mspid: Org4MSP
+    fullpath: true
+    peers:
+    - peer0.org4.HLNETWORK.com
+    certificateAuthorities:
+    - ca.org4.HLNETWORK.com
+    cryptopath: peerOrganizations/org4.HLNETWORK.com/msp
+    adminPrivateKey:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org4.HLNETWORK.com/users/Admin@org4.HLNETWORK.com/msp/keystore/adminKey4"
+    signedCert:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org4.HLNETWORK.com/users/Admin@org4.HLNETWORK.com/msp/signcerts/Admin@org4.HLNETWORK.com-cert.pem"
+  ordererOrg:
+    mspid: OrdererMSP
+    fullpath: true
+    cryptopath: ordererOrganizations/HLNETWORK.com/msp
+    adminPrivateKey:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/ordererOrganizations/HLNETWORK.com/users/Admin@HLNETWORK.com/msp/keystore/ordererAdminKey"
+    signedCert:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/ordererOrganizations/HLNETWORK.com/users/Admin@HLNETWORK.com/msp/signcerts/Admin@HLNETWORK.com-cert.pem"
+peers:
+  peer0.org1.HLNETWORK.com:
+    tlsCACerts:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org1.HLNETWORK.com/peers/peer0.org1.HLNETWORK.com/msp/tlscacerts/tlsca.org1.HLNETWORK.com-cert.pem"
+    url: grpcs://localhost:7051
+    grpcOptions:
+      ssl-target-name-override: peer0.org1.HLNETWORK.com
+  peer0.org2.HLNETWORK.com:
+    tlsCACerts:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org2.HLNETWORK.com/peers/peer0.org2.HLNETWORK.com/msp/tlscacerts/tlsca.org2.HLNETWORK.com-cert.pem"
+    url: grpcs://localhost:8051
+    grpcOptions:
+      ssl-target-name-override: peer0.org2.HLNETWORK.com
+  peer0.org3.HLNETWORK.com:
+    tlsCACerts:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org3.HLNETWORK.com/peers/peer0.org3.HLNETWORK.com/msp/tlscacerts/tlsca.org3.HLNETWORK.com-cert.pem"
+    url: grpcs://localhost:9051
+    grpcOptions:
+      ssl-target-name-override: peer0.org3.HLNETWORK.com
+  peer0.org4.HLNETWORK.com:
+    tlsCACerts:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org4.HLNETWORK.com/peers/peer0.org4.HLNETWORK.com/msp/tlscacerts/tlsca.org4.HLNETWORK.com-cert.pem"
+    url: grpcs://localhost:10051
+    grpcOptions:
+      ssl-target-name-override: peer0.org4.HLNETWORK.com
+orderers:
+  orderer.HLNETWORK.com:
+    tlsCACerts:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/ordererOrganizations/HLNETWORK.com/msp/tlscacerts/tlsca.HLNETWORK.com-cert.pem"
+    url: grpcs://localhost:7050
+    grpcOptions:
+      ssl-target-name-override: orderer.HLNETWORK.com
+
+certificateAuthorities:
+
+  ca.org1.HLNETWORK.com:
+    url: http://localhost:7054
+    caName: ca.org1.HLNETWORK.com
+    httpOptions:
+      verify: false
+    registrar:
+      enrollId: admin
+      enrollSecret: adminpw
+    tlsCACerts:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org1.HLNETWORK.com/peers/peer0.org1.HLNETWORK.com/msp/tlscacerts/tlsca.org1.HLNETWORK.com-cert.pem"
+  
+  ca.org2.HLNETWORK.com:
+    url: http://localhost:8054
+    caName: ca.org2.HLNETWORK.com
+    httpOptions:
+      verify: false
+    registrar:
+      enrollId: admin
+      enrollSecret: adminpw
+    tlsCACerts:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org2.HLNETWORK.com/peers/peer0.org2.HLNETWORK.com/msp/tlscacerts/tlsca.org2.HLNETWORK.com-cert.pem"
+
+  ca.org3.HLNETWORK.com:
+    url: http://localhost:9054
+    caName: ca.org3.HLNETWORK.com
+    httpOptions:
+      verify: false
+    registrar:
+      enrollId: admin
+      enrollSecret: adminpw
+    tlsCACerts:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org3.HLNETWORK.com/peers/peer0.org3.HLNETWORK.com/msp/tlscacerts/tlsca.org3.HLNETWORK.com-cert.pem"
+
+  ca.org4.HLNETWORK.com:
+    url: http://localhost:10054
+    caName: ca.org4.HLNETWORK.com
+    httpOptions:
+      verify: false
+    registrar:
+      enrollId: admin
+      enrollSecret: adminpw
+    tlsCACerts:
+      path: "/go/src/github.com/blockchain-analyzer/network/basic/crypto-config/peerOrganizations/org4.HLNETWORK.com/peers/peer0.org4.HLNETWORK.com/msp/tlscacerts/tlsca.org4.HLNETWORK.com-cert.pem"
+
+entityMatchers:
+  peer:
+    - pattern: (\w*)peer0.org1.HLNETWORK.com(\w*)
+      urlSubstitutionExp: localhost:7051
+      eventUrlSubstitutionExp: localhost:7053
+      sslTargetOverrideUrlSubstitutionExp: peer0.org1.HLNETWORK.com
+      mappedHost: peer0.org1.HLNETWORK.com
+    
+    - pattern: (\w*)peer0.org2.HLNETWORK.com(\w*)
+      urlSubstitutionExp: localhost:8051
+      eventUrlSubstitutionExp: localhost:8053
+      sslTargetOverrideUrlSubstitutionExp: peer0.org2.HLNETWORK.com
+      mappedHost: peer0.org2.HLNETWORK.com
+
+    - pattern: (\w*)peer0.org3.HLNETWORK.com(\w*)
+      urlSubstitutionExp: localhost:9051
+      eventUrlSubstitutionExp: localhost:9053
+      sslTargetOverrideUrlSubstitutionExp: peer0.org3.HLNETWORK.com
+      mappedHost: peer0.org3.HLNETWORK.com
+  
+    - pattern: (\w*)peer0.org4.HLNETWORK.com(\w*)
+      urlSubstitutionExp: localhost:10051
+      eventUrlSubstitutionExp: localhost:10053
+      sslTargetOverrideUrlSubstitutionExp: peer0.org4.HLNETWORK.com
+      mappedHost: peer0.org4.HLNETWORK.com
+
+  orderer:
+    - pattern: (\w*)orderer.HLNETWORK.com(\w*)
+      urlSubstitutionExp: localhost:7050
+      sslTargetOverrideUrlSubstitutionExp: orderer.HLNETWORK.com
+      mappedHost: orderer.HLNETWORK.com
+
+  certificateAuthorities:
+    - pattern: (\w*)ca.org1.HLNETWORK.com(\w*)
+      urlSubstitutionExp: http://localhost:7054
+      mappedHost: ca.org1.HLNETWORK.com
+
+    - pattern: (\w*)ca.org2.HLNETWORK.com(\w*)
+      urlSubstitutionExp: http://localhost:8054
+      mappedHost: ca.org2.HLNETWORK.com
+
+    - pattern: (\w*)ca.org3.HLNETWORK.com(\w*)
+      urlSubstitutionExp: http://localhost:9054
+      mappedHost: ca.org3.HLNETWORK.com
+
+    - pattern: (\w*)ca.org4.HLNETWORK.com(\w*)
+      urlSubstitutionExp: http://localhost:10054
+      mappedHost: ca.org4.HLNETWORK.com

--- a/docker-compose-fabricbeat.yml
+++ b/docker-compose-fabricbeat.yml
@@ -1,0 +1,30 @@
+version: "3"
+
+services:
+
+  fabricbeat:
+    container_name: fabricbeat-1
+    image: balazsprehoda/fabricbeat:v1-alpha
+    # To make resolution of peer container addresses simple (demo purposes!)
+    # In production, you probably want to deploy fabricbeat to the same network
+    # as the Hyperledger Fabric containers.
+    network_mode: host
+    environment:
+      - ORG_NUMBER=${ORG_NUMBER}
+      - PEER_NUMBER=${PEER_NUMBER}
+      - NETWORK=${NETWORK}
+    volumes:
+      # Configuration file - Remember to modify path variables (adminCertPath, adminKeyPath)
+      # to point to the mounted cryptographic artifacts! (in this case, this means replacing
+      # ${GOPATH} with the value of ${GOPATH} on the HOST machine)
+      - ./agent/fabricbeat/fabricbeat.yml:/go/src/github.com/blockchain-analyzer/agent/fabricbeat/fabricbeat.yml
+      # Connection profile ("connectionProfile" in configuration file)
+      - ${GOPATH}/src/github.com/blockchain-analyzer/network/${NETWORK}/connection-profile-${ORG_NUMBER}.yaml:/go/src/github.com/blockchain-analyzer/network/${NETWORK}/connection-profile-${ORG_NUMBER}.yaml
+      # Crypto-config
+      - ${GOPATH}/src/github.com/blockchain-analyzer/network/basic/crypto-config:${GOPATH}/src/github.com/blockchain-analyzer/network/basic/crypto-config
+      # Kibana dashboard directory ("dashboardDirectory" in configuration file)
+      - ${GOPATH}/src/github.com/blockchain-analyzer/dashboards/7/dashboard:/go/src/github.com/blockchain-analyzer/dashboards/7/dashboard
+      # Kibana template directory ("templateDirectory" in configuration file)
+      - ${GOPATH}/src/github.com/blockchain-analyzer/agent/kibana_templates:/go/src/github.com/blockchain-analyzer/agent/kibana_templates
+      # Note that if you change "dashboardDirectory", you have to change setup.dashboards.directory accordingly!
+

--- a/docs/Apple_setup_example.md
+++ b/docs/Apple_setup_example.md
@@ -7,7 +7,7 @@ This is an example to setup the project with applechain network on a new Ubuntu 
 Please make sure that you have set up the environment for the project. Follow the steps listed in [Prerequisites](https://github.com/balazsprehoda/hyperledger-elastic/blob/master/docs/Prerequisites.md).   
 
 ## Cloning the repository
-To get started with the project, we have to clone the repository first. It is important that we put it under `$GOPATH/src/github.com`. 
+To get started with the project, clone the git repository. If you want to build Fabricbeat yourself, it is important that you place the project under `$GOPATH/src/github.com`. Otherwise, you can clone the repository anywhere you want (you do not need to install Go to use the pre-compiled executable or the Docker image).
 ```
 mkdir -p $GOPATH/src/github.com
 cd $GOPATH/src/github.com
@@ -68,8 +68,10 @@ make start
 
 If you see *"Cannot connect to the Elasticsearch cluster"*, try refreshing the page, or opening the page in another tab.
 
-## Building and running the agent
-We use the agent to periodically query ledger data and ship it to Elasticsearch. To get started with the agent, run
+## Running the agent
+We use the agent to periodically query ledger data and ship it to Elasticsearch. To run the agent on your local machine, you can build it yourself or use a pre-compiled version the same way as described in `Basic_setup` and `Multichannel_setup`. To run it inside a Docker container, you can pull the image [balazsprehoda/fabricbeat](https://hub.docker.com/r/balazsprehoda/fabricbeat), or build the image using the Dockerfile in the project root directory. For reference on using the image, please see [`blockchain-analyzer/docker-agent`](https://github.com/hyperledger-labs/blockchain-analyzer/tree/master/docker-agent).
+
+Building locally:  
 ```
 cd ../agent/fabricbeat
 export PATH=$PATH:$GOPATH/bin

--- a/docs/Apple_setup_example.md
+++ b/docs/Apple_setup_example.md
@@ -69,7 +69,7 @@ make start
 If you see *"Cannot connect to the Elasticsearch cluster"*, try refreshing the page, or opening the page in another tab.
 
 ## Running the agent
-We use the agent to periodically query ledger data and ship it to Elasticsearch. To run the agent on your local machine, you can build it yourself or use a pre-compiled version the same way as described in `Basic_setup` and `Multichannel_setup`. To run it inside a Docker container, you can pull the image [balazsprehoda/fabricbeat](https://hub.docker.com/r/balazsprehoda/fabricbeat), or build the image using the Dockerfile in the project root directory. For reference on using the image, please see [`blockchain-analyzer/docker-agent`](https://github.com/hyperledger-labs/blockchain-analyzer/tree/master/docker-agent).
+We use the agent to periodically query ledger data and ship it to Elasticsearch. To run the agent on your local machine, you can build it yourself or use a pre-compiled version the same way as described in [`Basic setup`](https://github.com/hyperledger-labs/blockchain-analyzer/blob/master/docs/Basic_setup.md) and [`Multichannel setup`](https://github.com/hyperledger-labs/blockchain-analyzer/blob/master/docs/Multichannel_setup.md). To run it inside a Docker container, you can pull the image [balazsprehoda/fabricbeat](https://hub.docker.com/r/balazsprehoda/fabricbeat), or build the image using the Dockerfile in the project root directory. For reference on using the image, please see [`blockchain-analyzer/docker-agent`](https://github.com/hyperledger-labs/blockchain-analyzer/tree/master/docker-agent).
 
 Building locally:  
 ```
@@ -78,7 +78,7 @@ export PATH=$PATH:$GOPATH/bin
 make update
 ```
 
-Afte updating, build the agent:
+After updating, build the agent:
 
 ```
 make

--- a/docs/Basic_setup.md
+++ b/docs/Basic_setup.md
@@ -7,10 +7,9 @@ This is an example to setup the project with `basic` network on a new Ubuntu 18.
 3. [Start / stop a Hyperledger Fabric network using `basic` configuration](#start--stop-the-basic-network). See `multichannel` page for multi-channel configuration.
 4. [Create users and transactions using dummy application](#create-users-and-transactions-using-dummy-application)
 5. [Start Elastic stack](#start-elastic-stack)
-6. [Build fabricbeat agent](#build-fabricbeat-agent)
-7. [Start the fabricbeat agent](#start-fabricbeat) and connect to peer in `basic` network
-8. [Configuring Indices for the first time in Kibana](#configuring-indices-for-the-first-time-in-Kibana)
-9. [Viewing dashboards](#viewing-dashboards) that store data
+6. [Fabricbeat agent](#fabricbeat-agent)
+7. [Configuring Indices for the first time in Kibana](#configuring-indices-for-the-first-time-in-Kibana)
+8. [Viewing dashboards](#viewing-dashboards) that store data
 
 ## Install Prerequisites
 

--- a/docs/Basic_setup.md
+++ b/docs/Basic_setup.md
@@ -152,11 +152,12 @@ $ docker build -t <IMAGE NAME> .
 ```  
 from the project root directory.
 
-To start the agent, you have to mount two configuration files and the necessary crypto materials:
+To start the agent, you have to mount two configuration files, the necessary crypto materials and the folders that contain kibana dashboards and templates:
 
 - `fabricbeat.yml`: configuration file for the agent (see `blockchain-analyzer/agent/fabricbeat/fabricbeat.yml` for reference)
 - connection profile yaml file referenced from `fabricbeat.yml`
 - crypto materials referenced from the connection profile and `fabricbeat.yml`
+- Kibana dashboard and template directories referenced as `dashboardDirectory` and `templateDirectory` in the configuration file.
 
 If you use environment variables in the configuration file, do not forget to set these variables in the container!
 

--- a/docs/Basic_setup.md
+++ b/docs/Basic_setup.md
@@ -17,7 +17,7 @@ This is an example to setup the project with `basic` network on a new Ubuntu 18.
 Please make sure that you have set up the environment for the project. Follow the steps listed in [Prerequisites](https://github.com/balazsprehoda/hyperledger-elastic/blob/master/docs/Prerequisites.md).   
 
 ## Clone the repository
-To get started with the project, clone the git repository. It is important that you place it under `$GOPATH/src/github.com`  
+To get started with the project, clone the git repository. If you want to build Fabricbeat yourself, it is important that you place the project under `$GOPATH/src/github.com`. Otherwise, you can clone the repository anywhere you want (you do not need to install Go to use the pre-compiled executable or the Docker image). 
 ```
 $ mkdir $GOPATH/src/github.com -p
 $ cd $GOPATH/src/github.com  
@@ -37,12 +37,12 @@ Issue the following command in the `network/basic` directory
 make start
 ```
 
-Enter the Fabric CLI Docker container by issuing the command:
+To enter the Fabric CLI Docker container, issue the command:
 ```
 docker exec -it cli bash  
 ```
 
-Inside the CLI, the `/scripts` folder contains the scripts that can be used to install, instantiate and invoke chaincode (though the `make start` command takes care of installation and instantiation).
+Inside CLI, the `/scripts` folder contains scripts that can be used to install, instantiate and invoke chaincode (though the `make start` command takes care of installation and instantiation).
 
 ### Stop the network
 
@@ -55,7 +55,7 @@ make destroy
 
 ### Remove chaincode images
 
-If you make changes to `dummycc` chain code, you will need to remove the old images:
+If you make changes to `dummycc` chaincode, you will need to remove the old images:
 
 ```
 make rmchaincode
@@ -141,14 +141,35 @@ make erase
 ```
 
 
-## Build Fabricbeat Agent
+## Fabricbeat Agent
 
-The fabricbeat beats agent is responsible for connecting to a specified peer, periodically querying its ledger, processing the data and shipping it to Elasticsearch. Multiple instances can be run at the same time, each querying a different peer and sending its data to the Elasticsearch cluster.  
+The fabricbeat Beats agent is responsible for connecting to a specified peer, periodically querying its ledger, processing the data and shipping it to Elasticsearch. Multiple instances can be run at the same time, each querying a different peer and sending its data to the Elasticsearch cluster.  
+
+### Docker image
+
+Fabricbeat agent is also available as a Docker image ([balazsprehoda/fabricbeat](https://hub.docker.com/r/balazsprehoda/fabricbeat)). You can use this image, or build it using the command  
+```
+$ docker build -t <IMAGE NAME> .
+```  
+from the project root directory.
+
+To start the agent, you have to mount two configuration files and the necessary crypto materials:
+
+- `fabricbeat.yml`: configuration file for the agent (see `blockchain-analyzer/agent/fabricbeat/fabricbeat.yml` for reference)
+- connection profile yaml file referenced from `fabricbeat.yml`
+- crypto materials referenced from the connection profile and `fabricbeat.yml`
+
+If you use environment variables in the configuration file, do not forget to set these variables in the container!
+
+For a sample Docker setup, see [`/blockchain-analyzer/docker-agent/`](https://github.com/hyperledger-labs/blockchain-analyzer/tree/master/docker-agent).
+
+### Running the agent locally
+
 The commands in this section should be issued from the `blockchain-analyzer/agent/fabricbeat` directory.
 
 You can build the agent yourself, or you can use a pre-built one from the `blockchain-analyzer/agent/fabricbeat/prebuilt` directory. To use an executable from the `prebuilt` dir, choose the appropriate for your system and copy it into the `blockchain-analyzer/agent/fabricbeat` folder.
 
-### Environment setup
+#### Environment setup
 
 Before configuring and building the fabricbeat agent, please make sure that the `GOPATH` variable is set correctly. Then, add `$GOPATH/bin` to the `PATH`:
 ```
@@ -169,7 +190,7 @@ make
 ```
 
 
-## Start fabricbeat
+#### Start fabricbeat locally
 
 To start the agent, issue the following command from the `fabricbeat` directory:
 ```
@@ -181,12 +202,12 @@ ORG_NUMBER=1 PEER_NUMBER=0 NETWORK=basic ./fabricbeat -e -d "*"
 ```
 The variables passed are used in the configuration (`fabricbeat.yml`). To connect to another network or peer, change the configuration (and/or the passed variables) accordingly.
 
-### Stop fabricbeat
+#### Stop fabricbeat
 
 To stop the agent, simply type `Ctrl+C`
 
 
-## Configuring Indices for the first time in Kibana
+### Configuring Indices for the first time in Kibana
 
 Next, we navigate to http://localhost:5601.
 
@@ -194,7 +215,7 @@ Click the dashboards icon on the left:
 ![alt text](https://github.com/hyperledger-labs/blockchain-analyzer/blob/master/docs/images/Starting_page.png "Kibana starting page")
 
 
-Kibana takes us to select a default index pattern. Click `fabricbeat-*`, then the star in the upper right corner:
+Kibana takes us to select a default index pattern. Click `fabricbeat-*`, then the star in the top right corner:
 ![alt text](https://github.com/hyperledger-labs/blockchain-analyzer/blob/master/docs/images/Index_pattern_selection_basic.png "Setting default index pattern")
 
 

--- a/docs/Basic_setup.md
+++ b/docs/Basic_setup.md
@@ -146,6 +146,8 @@ make erase
 The fabricbeat beats agent is responsible for connecting to a specified peer, periodically querying its ledger, processing the data and shipping it to Elasticsearch. Multiple instances can be run at the same time, each querying a different peer and sending its data to the Elasticsearch cluster.  
 The commands in this section should be issued from the `blockchain-analyzer/agent/fabricbeat` directory.
 
+You can build the agent yourself, or you can use a pre-built one from the `blockchain-analyzer/agent/fabricbeat/prebuilt` directory. To use an executable from the `prebuilt` dir, choose the appropriate for your system and copy it into the `blockchain-analyzer/agent/fabricbeat` folder.
+
 ### Environment setup
 
 Before configuring and building the fabricbeat agent, please make sure that the `GOPATH` variable is set correctly. Then, add `$GOPATH/bin` to the `PATH`:

--- a/docs/Multichannel_setup.md
+++ b/docs/Multichannel_setup.md
@@ -150,11 +150,12 @@ $ docker build -t <IMAGE NAME> .
 ```  
 from the project root directory.
 
-To start the agent, you have to mount two configuration files and the necessary crypto materials:
+To start the agent, you have to mount two configuration files, the necessary crypto materials and the folders that contain kibana dashboards and templates:
 
 - `fabricbeat.yml`: configuration file for the agent (see `blockchain-analyzer/agent/fabricbeat/fabricbeat.yml` for reference)
 - connection profile yaml file referenced from `fabricbeat.yml`
 - crypto materials referenced from the connection profile and `fabricbeat.yml`
+- Kibana dashboard and template directories referenced as `dashboardDirectory` and `templateDirectory` in the configuration file.
 
 If you use environment variables in the configuration file, do not forget to set these variables in the container!
 

--- a/docs/Multichannel_setup.md
+++ b/docs/Multichannel_setup.md
@@ -7,18 +7,17 @@ This is an example to setup the project with `multichannel` network on a new Ubu
 3. [Start / stop a Hyperledger Fabric network using `multichannel` configuration](#start--stop-the-multichannel-network). See `multichannel` page for multi-channel configuration.
 4. [Create users and transactions using dummy application](#create-users-and-transactions-using-dummy-application)
 5. [Start Elastic stack](#start-elastic-stack)
-6. [Build fabricbeat agent](#build-fabricbeat-agent)
-7. [Start the fabricbeat agent](#start-fabricbeat) and connect to peer in `basic` network
-8. [Configuring Indices for the first time in Kibana](#configuring-indices-for-the-first-time-in-Kibana)
-9. [Viewing dashboards](#viewing-dashboards) that store data
-10. [Starting more instances of fabricbeat agent](#starting-more-instances-of-fabricbeat-agent)
+6. [Fabricbeat agent](#fabricbeat-agent)
+7. [Configuring Indices for the first time in Kibana](#configuring-indices-for-the-first-time-in-Kibana)
+8. [Viewing dashboards](#viewing-dashboards) that store data
+9. [Starting more instances of fabricbeat agent](#starting-more-instances-of-fabricbeat-agent)
 
 ## Install Prerequisites
 
 Please make sure that you have set up the environment for the project. Follow the steps listed in [Prerequisites](https://github.com/balazsprehoda/hyperledger-elastic/blob/master/docs/Prerequisites.md).   
 
 ## Clone the repository
-To get started with the project, clone the git repository. It is important that you place it under `$GOPATH/src/github.com`  
+To get started with the project, clone the git repository. If you want to build Fabricbeat yourself, it is important that you place the project under `$GOPATH/src/github.com`. Otherwise, you can clone the repository anywhere you want (you do not need to install Go to use the pre-compiled executable or the Docker image).  
 ```
 $ mkdir $GOPATH/src/github.com -p
 $ cd $GOPATH/src/github.com  
@@ -139,22 +138,46 @@ make erase
 ```
 
 
-## Build Fabricbeat Agent
+## Fabricbeat Agent
 
 The fabricbeat beats agent is responsible for connecting to a specified peer, periodically querying its ledger, processing the data and shipping it to Elasticsearch. Multiple instances can be run at the same time, each querying a different peer and sending its data to the Elasticsearch cluster.  
+
+### Docker image
+
+Fabricbeat agent is also available as a Docker image ([balazsprehoda/fabricbeat](https://hub.docker.com/r/balazsprehoda/fabricbeat)). You can use this image, or build it using the command  
+```
+$ docker build -t <IMAGE NAME> .
+```  
+from the project root directory.
+
+To start the agent, you have to mount two configuration files and the necessary crypto materials:
+
+- `fabricbeat.yml`: configuration file for the agent (see `blockchain-analyzer/agent/fabricbeat/fabricbeat.yml` for reference)
+- connection profile yaml file referenced from `fabricbeat.yml`
+- crypto materials referenced from the connection profile and `fabricbeat.yml`
+
+If you use environment variables in the configuration file, do not forget to set these variables in the container!
+
+For a sample Docker setup, see [`/blockchain-analyzer/docker-agent/`](https://github.com/hyperledger-labs/blockchain-analyzer/tree/master/docker-agent).
+
+### Running the agent locally
+
 The commands in this section should be issued from the `blockchain-analyzer/agent/fabricbeat` directory.
 
-### Environment setup
+You can build the agent yourself, or you can use a pre-built one from the `blockchain-analyzer/agent/fabricbeat/prebuilt` directory. To use an executable from the `prebuilt` dir, choose the appropriate for your system and copy it into the `blockchain-analyzer/agent/fabricbeat` folder.
+
+#### Environment setup
 
 Before configuring and building the fabricbeat agent, please make sure that the `GOPATH` variable is set correctly. Then, add `$GOPATH/bin` to the `PATH`:
 ```
 export PATH=$PATH:$GOPATH/bin
 ```
+
 Ensure that Python version is 2.7.*. 
 
 Get module dependencies:
 ```
-make get-go
+make go-get
 ```
 
 Build the agent:
@@ -163,7 +186,7 @@ make update
 make
 ```
 
-## Start fabricbeat
+#### Start fabricbeat locally
 
 To start the agent, issue the following command from the `fabricbeat` directory:
 ```
@@ -175,7 +198,7 @@ ORG_NUMBER=1 PEER_NUMBER=0 NETWORK=multichannel ./fabricbeat -e -d "*"
 ```
 The variables passed are used in the configuration (`fabricbeat.yml`). To connect to another network or peer, change the configuration (and/or the passed variables) accordingly.
 
-### Stop fabricbeat
+#### Stop fabricbeat
 
 To stop the agent, simply type `Ctrl+C`
 

--- a/docs/Prerequisites.md
+++ b/docs/Prerequisites.md
@@ -1,10 +1,14 @@
 ## Prerequisites
-* Go (v1.12.7+)  
+
 * Docker  (v19.03.0+)
 * docker-compose (v1.24.1+)  
 * Node.js (v8.10+)  
+
+The following are necessary only if you want to build Fabricbeat yourself. If you intend to use the Docker image ([balazsprehoda/fabricbeat](https://hub.docker.com/repository/docker/balazsprehoda/fabricbeat/general)) or the pre-compiled executable, you can skip them.
+
 * python (2.7) 
 * virtualenv (16.7.0+)  
+* Go (v1.12.7+)  
 
 The instructions below have been tested on a Ubuntu 16.04 machine in AWS:
 

--- a/network/basic/chaincode/dummycc/package.json
+++ b/network/basic/chaincode/dummycc/package.json
@@ -14,8 +14,8 @@
     "author": "",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "~1.4.0",
-        "fabric-shim": "~1.4.0",
+        "fabric-contract-api": "1.4.0",
+        "fabric-shim": "1.4.0",
         "crypto": "^1.0.1"
     }
 }


### PR DESCRIPTION
This pull request includes:
- Pre-compiled fabricbeat agent for (built on Ubuntu 18.04 LTS)
- Dockerfile to build fabricbeat image. ( resolves #32 )
- Example for demonstration of fabricbeat image usage.
- Documentation updates to include Docker option in prerequisites and setups.
- Binding node chaincode version to 1.4.0 in dummycc to enable variable parameter count. ( resolves #36 )
- Usage of fabric/protoutil Go package for hash generation.

I also published a Docker image for fabricbeat on Dockerhub: https://hub.docker.com/r/balazsprehoda/fabricbeat

By using pre-compiled or Docker version of the agent, the project can be independent from Go, Python and virtualenv and all the inconvenience coming with them. I hope this makes the project more user-friendly.
